### PR TITLE
refac: remove hive default catalog

### DIFF
--- a/.github/workflows/create-release-tag.yml
+++ b/.github/workflows/create-release-tag.yml
@@ -21,7 +21,7 @@ jobs:
           # See https://github.com/Energinet-DataHub/.github#release-procedure for details
           major_version: 1
           minor_version: 9
-          patch_version: 2
+          patch_version: 3
           repository_path: Energinet-DataHub/opengeh-python-packages
         env:
           GH_TOKEN: ${{ steps.generate_token.outputs.token }}

--- a/source/spark_sql_migrations/spark_sql_migrations/constants/catalog_constants.py
+++ b/source/spark_sql_migrations/spark_sql_migrations/constants/catalog_constants.py
@@ -1,4 +1,0 @@
-class Catalog:
-    default_hive_metastore = "hive_metastore"
-    test_hive_metastore = "spark_catalog"
-    hive_metastores = [default_hive_metastore, test_hive_metastore]

--- a/source/spark_sql_migrations/spark_sql_migrations/models/spark_sql_migrations_configuration.py
+++ b/source/spark_sql_migrations/spark_sql_migrations/models/spark_sql_migrations_configuration.py
@@ -1,5 +1,6 @@
 from dataclasses import dataclass
 
+
 @dataclass
 class SparkSqlMigrationsConfiguration:
     migration_schema_name: str

--- a/source/spark_sql_migrations/spark_sql_migrations/models/spark_sql_migrations_configuration.py
+++ b/source/spark_sql_migrations/spark_sql_migrations/models/spark_sql_migrations_configuration.py
@@ -1,8 +1,5 @@
 from dataclasses import dataclass
 
-from spark_sql_migrations.constants.catalog_constants import Catalog
-
-
 @dataclass
 class SparkSqlMigrationsConfiguration:
     migration_schema_name: str
@@ -19,9 +16,9 @@ class SparkSqlMigrationsConfiguration:
     """The schema configuration, telling the migration tool which schemas and tables to check."""
     substitution_variables: dict[str, str]
     """The substitution variables. These are used to replace variables in the migration scripts"""
+    catalog_name: str
+    """The name of the catalog"""
     current_state_schemas_folder_path: str = ""
     """(Optional) The folder path to the schema files"""
     table_prefix: str = ""
     """(Optional) A prefix to use for the table name"""
-    catalog_name: str = Catalog.default_hive_metastore
-    """(Optional) The name of the catalog"""


### PR DESCRIPTION
SparkSqlMigrationsConfiguration no longer defaults to hive_metastore as catalog name, so now it is not an optional property.
