### PR TITLE
fix: Set version inside loop

### DIFF
--- a/.github/workflows/create-release-tag.yml
+++ b/.github/workflows/create-release-tag.yml
@@ -21,7 +21,7 @@ jobs:
           # See https://github.com/Energinet-DataHub/.github#release-procedure for details
           major_version: 1
           minor_version: 9
-          patch_version: 3
+          patch_version: 4
           repository_path: Energinet-DataHub/opengeh-python-packages
         env:
           GH_TOKEN: ${{ steps.generate_token.outputs.token }}

--- a/source/spark_sql_migrations/tests/helpers/test_schemas.py
+++ b/source/spark_sql_migrations/tests/helpers/test_schemas.py
@@ -4,8 +4,9 @@ from pyspark.sql.types import (
     StringType,
 )
 
-from spark_sql_migrations.models.table import Table
+from pyspark.sql import SparkSession
 from spark_sql_migrations.models.view import View
+from spark_sql_migrations.models.table import Table
 from spark_sql_migrations.models.schema import Schema
 
 
@@ -26,3 +27,13 @@ schema_config = [
         views=[View(name="test_view", schema=schema)],
     )
 ]
+
+
+def create_test_tables(spark: SparkSession) -> None:
+    spark.sql("CREATE DATABASE IF NOT EXISTS spark_catalog.test_schema")
+    spark.sql(
+        "CREATE TABLE IF NOT EXISTS spark_catalog.test_schema.test_table (column1 STRING, column2 STRING) USING DELTA"
+    )
+    spark.sql(
+        "CREATE TABLE IF NOT EXISTS spark_catalog.test_schema.test_table_2 (column1 STRING, column2 STRING) USING DELTA"
+    )

--- a/source/spark_sql_migrations/tests/test_scripts/migration_test_restore.sql
+++ b/source/spark_sql_migrations/tests/test_scripts/migration_test_restore.sql
@@ -1,0 +1,2 @@
+ALTER TABLE spark_catalog.test_schema.test_table
+ADD COLUMNS (column3 STRING)

--- a/source/spark_sql_migrations/tests/test_scripts/migration_test_restore_2.sql
+++ b/source/spark_sql_migrations/tests/test_scripts/migration_test_restore_2.sql
@@ -1,0 +1,2 @@
+ALTER TABLE spark_catalog.test_schema.test_table
+ADD COLUMNS (column4 STRING)


### PR DESCRIPTION
This pull request fixes a bug.

The bug happens when you try to apply 2 migration scripts. One of the scripts goes well, however, the second script fails. This triggers a restoration of the tables. However, the restore restores the states before both scripts are executed. This means that we are now in an invalid state, where it seems like a script has been executed but the tables are restored.

