### PR TITLE
fix: create executed_migration table in current state

### DIFF
--- a/.github/workflows/create-release-tag.yml
+++ b/.github/workflows/create-release-tag.yml
@@ -20,7 +20,7 @@ jobs:
           # BE AWARE --> Updating to a new MAJOR version will delete deprecated versions on a nightly schedule.
           # See https://github.com/Energinet-DataHub/.github#release-procedure for details
           major_version: 2
-          minor_version: 1
+          minor_version: 2
           patch_version: 0
           repository_path: Energinet-DataHub/opengeh-python-packages
         env:


### PR DESCRIPTION
If executed_migration table does not exist when deploying the current state, it fails.
