### PR TITLE
Update pyspark-slim-publish.yml

### DIFF
--- a/.github/workflows/pyspark-slim-publish.yml
+++ b/.github/workflows/pyspark-slim-publish.yml
@@ -42,7 +42,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Read versions from yaml
-        uses: pietrobolcato/action-read-yaml@1.0.0
+        uses: pietrobolcato/action-read-yaml@1.1.0
         id: build_config
         with:
           config: container-images/pyspark-slim/build-config.yml


### PR DESCRIPTION
This pull request updates the version of an action used in the GitHub workflow file `.github/workflows/pyspark-slim-publish.yml`. The change involves upgrading the `pietrobolcato/action-read-yaml` action from version `1.0.0` to `1.1.0`.

* Updated the `pietrobolcato/action-read-yaml` action version from `1.0.0` to `1.1.0` in the `jobs:` section of the `.github/workflows/pyspark-slim-publish.yml` file.