### PR TITLE
Use same user for docker images and in GitHub Actions runner

### DIFF
--- a/.devcontainer/docker-compose-windows.yml
+++ b/.devcontainer/docker-compose-windows.yml
@@ -5,9 +5,10 @@ services:
       # Forwards the local Docker socket to the container.
       - /var/run/docker.sock:/var/run/docker-host.sock
       # Update this to wherever you want VS Code to mount the folder of your project
-      - ..:/workspaces/opengeh-python-packages:cached
+      - ..:${HOME}/work/opengeh-python-packages:cached
       # Map to Azure CLI token cache location (on Windows)
-      - "${USERPROFILE}/.azure:/home/joyvan/.azure"
+      - "${USERPROFILE}/.azure:/home/jovyan/.azure"
+    working_dir: ${HOME}/work/opengeh-python-packages
     environment:
       # Pass the environment variables from your shell straight through to your containers.
       # No warning is issued if the variable in the shell environment is not set.

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -5,9 +5,10 @@ services:
       # Forwards the local Docker socket to the container.
       - /var/run/docker.sock:/var/run/docker-host.sock
       # Update this to wherever you want VS Code to mount the folder of your project
-      - ..:/workspaces/opengeh-python-packages:cached
+      - ..:${HOME}/work/opengeh-python-packages:cached
       # Map to Azure CLI token cache location (on Linux)
-      - "${HOME}/.azure:/home/joyvan/.azure"
+      - "${HOME}/.azure:/home/jovyan/.azure"
+    working_dir: ${HOME}/work/opengeh-python-packages
     environment:
       # Pass the environment variables from your shell straight through to your containers.
       # No warning is issued if the variable in the shell environment is not set.

--- a/.docker/Dockerfile
+++ b/.docker/Dockerfile
@@ -54,6 +54,9 @@ ENV PATH=$SPARK_HOME/bin:$HADOOP_HOME/bin:$PATH \
 # Dynamically downloading spark dependencies from conf/spark-defaults.conf. This is done to save time in the build pipeline so that we don't need to download on every build.
 RUN spark-shell
 
-# Make $HOME owned by the root, which is the user used in the container
-# This is needed for e.g. commands that create files or folders in $HOME
-RUN sudo chown -R root:users $HOME
+# Change the username from jovyan to nayvoj and update the user id to 1001, as that is the user id used in the GitHub Actions runner
+RUN usermod -l nayvoj jovyan && \
+    usermod -u 1001 nayvoj && \
+    usermod -l jovyan nayvoj
+
+RUN usermod -u 1001 jovyan

--- a/.docker/entrypoint.sh
+++ b/.docker/entrypoint.sh
@@ -1,4 +1,4 @@
-#!/bin/bash -l
+#!/bin/bash
 
 # Copyright 2020 Energinet DataHub A/S
 #
@@ -21,7 +21,7 @@ echo "Tests folder path: '$1'"
 echo "Filter (paths): '$2'"
 
 # Configure Azure CLI to use token cache which must be mapped as volume from host machine
-export AZURE_CONFIG_DIR=/home/joyvan/.azure
+export AZURE_CONFIG_DIR=/home/jovyan/.azure
 
 # There env vars are important to ensure that the driver and worker nodes in spark are alligned
 export PYSPARK_PYTHON=/opt/conda/bin/python

--- a/.github/workflows/ci-orchestrator.yml
+++ b/.github/workflows/ci-orchestrator.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   # License and Markdown Check
   ci_base:
-    uses: Energinet-DataHub/.github/.github/workflows/ci-base.yml@v13
+    uses: Energinet-DataHub/.github/.github/workflows/ci-base.yml@v14
     with:
       skip_license_check: true
     secrets:
@@ -19,7 +19,7 @@ jobs:
 
   ci_docker:
     needs: changes
-    uses: Energinet-DataHub/.github/.github/workflows/python-build-and-push-docker-image.yml@v13
+    uses: Energinet-DataHub/.github/.github/workflows/python-build-and-push-docker-image.yml@v14
     with:
       docker_changed: ${{ needs.changes.outputs.docker == 'true' }}
       docker_changed_in_commit: ${{ needs.changes.outputs.docker_in_commit == 'true' }}


### PR DESCRIPTION
This pull request includes several changes to the Docker and development environment configurations to improve consistency and functionality. The most important changes include updating mount paths and user configurations.

Updates to mount paths and user configurations:

* [`.devcontainer/docker-compose-windows.yml`](diffhunk://#diff-7da8718dba02e6f1fc48c79f17aa699ab5dec440ecc37d751a5480d3035fadcfL8-R11): Updated the mount path for the project folder and Azure CLI token cache location, and set the working directory.
* [`.devcontainer/docker-compose.yml`](diffhunk://#diff-67a4805fdcc6145d7b3ada2a6099a9b2e91c9d0fd108c22f95d2f01d219793d1L8-R11): Updated the mount path for the project folder and Azure CLI token cache location, and set the working directory.
* [`.docker/Dockerfile`](diffhunk://#diff-38801fa32c4bd7bd97aa3c87c138be36e126e0337b22aacf27ab57365357dc20L57-R62): Changed the username from `jovyan` to `nayvoj` and updated the user ID to match the GitHub Actions runner.

Minor adjustments:

* [`.docker/entrypoint.sh`](diffhunk://#diff-d464f2255f2f24bca648f9c24fc26ecba642be2efd7afc78fb080232dee04524L1-R1): Changed the shebang from `#!/bin/bash -l` to `#!/bin/bash` and updated the Azure CLI token cache environment variable. [[1]](diffhunk://#diff-d464f2255f2f24bca648f9c24fc26ecba642be2efd7afc78fb080232dee04524L1-R1) [[2]](diffhunk://#diff-d464f2255f2f24bca648f9c24fc26ecba642be2efd7afc78fb080232dee04524L24-R24)