### PR TITLE
refac: Spark Sql Migrations - Move configuration 

### DIFF
--- a/.github/workflows/create-release-tag.yml
+++ b/.github/workflows/create-release-tag.yml
@@ -20,8 +20,8 @@ jobs:
           # BE AWARE --> Updating to a new MAJOR version will delete deprecated versions on a nightly schedule.
           # See https://github.com/Energinet-DataHub/.github#release-procedure for details
           major_version: 3
-          minor_version: 0
-          patch_version: 2
+          minor_version: 1
+          patch_version: 0
           repository_path: Energinet-DataHub/opengeh-python-packages
         env:
           GH_TOKEN: ${{ steps.generate_token.outputs.token }}

--- a/source/spark_sql_migrations/README.md
+++ b/source/spark_sql_migrations/README.md
@@ -7,7 +7,6 @@
 ```python
 
 from spark_sql_migrations import (
-    create_and_configure_container,
     migration_pipeline,
     SparkSqlMigrationsConfiguration,
 )
@@ -36,8 +35,7 @@ spark_config = SparkSqlMigrationsConfiguration(
     catalog_name="spark_catalog",
 )
 
-create_and_configure_container(spark_config)
-migration_pipeline.migrate()
+migration_pipeline.migrate(spark_config)
 
 
 ```

--- a/source/spark_sql_migrations/release-notes/release-notes.md
+++ b/source/spark_sql_migrations/release-notes/release-notes.md
@@ -1,5 +1,13 @@
 # Spark SQL Migrations Release Notes
 
+## Version 3.1.0
+
+Following changes were made to simplify the package's usage and reduce the consumer's need to understand its
+implementation details
+
+- Removed the use of `create_and_configure_container` for the consumer.
+- The `migrate` function now takes `SparkSqlMigrationsConfigurations` as a parameter.
+
 ## Version 3.0.0
 
 Breaking changes

--- a/source/spark_sql_migrations/spark_sql_migrations/__init__.py
+++ b/source/spark_sql_migrations/spark_sql_migrations/__init__.py
@@ -1,5 +1,4 @@
 import spark_sql_migrations.migration_pipeline as schema_migration_pipeline
-from spark_sql_migrations.container import create_and_configure_container
 from spark_sql_migrations.models.spark_sql_migrations_configuration import (
     SparkSqlMigrationsConfiguration,
 )

--- a/source/spark_sql_migrations/spark_sql_migrations/migration_pipeline.py
+++ b/source/spark_sql_migrations/spark_sql_migrations/migration_pipeline.py
@@ -1,8 +1,16 @@
 import spark_sql_migrations.infrastructure.uncommitted_migration_scripts as uncommitted_migrations
 import spark_sql_migrations.infrastructure.apply_migration_scripts as apply_migrations
+from spark_sql_migrations.container import create_and_configure_container
 
 
-def migrate() -> None:
+def migrate(configuration: SparkSqlMigrationsConfiguration) -> None:
+    _configure_spark_sql_migrations(configuration)
+    _migrate()
+
+def _migrate() -> None:
     migrations: list[str] = uncommitted_migrations.get_uncommitted_migration_scripts()
     if len(migrations) > 0:
         (apply_migrations.apply_migration_scripts(migrations))
+
+def _configure_spark_sql_migrations(configuration: SparkSqlMigrationsConfiguration) -> None:
+    create_and_configure_container(configuration)

--- a/source/spark_sql_migrations/spark_sql_migrations/migration_pipeline.py
+++ b/source/spark_sql_migrations/spark_sql_migrations/migration_pipeline.py
@@ -1,16 +1,19 @@
 import spark_sql_migrations.infrastructure.uncommitted_migration_scripts as uncommitted_migrations
 import spark_sql_migrations.infrastructure.apply_migration_scripts as apply_migrations
 from spark_sql_migrations.container import create_and_configure_container
+from spark_sql_migrations.models.spark_sql_migrations_configuration import SparkSqlMigrationsConfiguration
 
 
 def migrate(configuration: SparkSqlMigrationsConfiguration) -> None:
     _configure_spark_sql_migrations(configuration)
     _migrate()
 
+
 def _migrate() -> None:
     migrations: list[str] = uncommitted_migrations.get_uncommitted_migration_scripts()
     if len(migrations) > 0:
         (apply_migrations.apply_migration_scripts(migrations))
+
 
 def _configure_spark_sql_migrations(configuration: SparkSqlMigrationsConfiguration) -> None:
     create_and_configure_container(configuration)

--- a/source/spark_sql_migrations/tests/conftest.py
+++ b/source/spark_sql_migrations/tests/conftest.py
@@ -15,14 +15,6 @@ from tests.builders.spark_sql_migrations_configuration_builder import (
 )
 
 
-def pytest_runtest_setup() -> None:
-    """
-    This function is called before each test function is executed.
-    """
-
-    create_and_configure_container(build_configuration())
-
-
 @pytest.fixture(scope="session")
 def spark() -> Generator[SparkSession, None, None]:
     warehouse_location = os.path.abspath("spark-warehouse")

--- a/source/spark_sql_migrations/tests/test_schema_migration_pipeline.py
+++ b/source/spark_sql_migrations/tests/test_schema_migration_pipeline.py
@@ -4,6 +4,7 @@ import spark_sql_migrations.infrastructure.uncommitted_migration_scripts as unco
 import spark_sql_migrations.infrastructure.apply_migration_scripts as apply_migrations
 import tests.builders.spark_sql_migrations_configuration_builder as spark_sql_migrations_configuration_builder
 
+
 def test__migrate__when_no_uncommitted_migrations__should_not_call_apply_migrations(
     mocker: Mock,
 ) -> None:

--- a/source/spark_sql_migrations/tests/test_schema_migration_pipeline.py
+++ b/source/spark_sql_migrations/tests/test_schema_migration_pipeline.py
@@ -2,12 +2,13 @@
 import spark_sql_migrations.migration_pipeline as sut
 import spark_sql_migrations.infrastructure.uncommitted_migration_scripts as uncommitted_migrations
 import spark_sql_migrations.infrastructure.apply_migration_scripts as apply_migrations
-
+import tests.builders.spark_sql_migrations_configuration_builder as spark_sql_migrations_configuration_builder
 
 def test__migrate__when_no_uncommitted_migrations__should_not_call_apply_migrations(
     mocker: Mock,
 ) -> None:
     # Arrange
+    config = spark_sql_migrations_configuration_builder.build()
     mocker.patch.object(
         uncommitted_migrations,
         uncommitted_migrations.get_uncommitted_migration_scripts.__name__,
@@ -19,7 +20,7 @@ def test__migrate__when_no_uncommitted_migrations__should_not_call_apply_migrati
     )
 
     # Act
-    sut.migrate()
+    sut.migrate(config)
 
     # Assert
     mocked_apply_migrations.assert_not_called()
@@ -29,6 +30,7 @@ def test__migrate__when_uncommitted_migrations_not_zero__should_call_apply_migra
     mocker: Mock,
 ) -> None:
     # Arrange
+    config = spark_sql_migrations_configuration_builder.build()
     mocker.patch.object(
         uncommitted_migrations,
         uncommitted_migrations.get_uncommitted_migration_scripts.__name__,
@@ -41,7 +43,7 @@ def test__migrate__when_uncommitted_migrations_not_zero__should_call_apply_migra
     )
 
     # Act
-    sut.migrate()
+    sut.migrate(config)
 
     # Assert
     mocked_apply_migrations.assert_called_once()


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open-source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/opengeh-wholesale) before we can accept your contribution. --->

# Description

<!-- INSERT DESCRIPTION HERE -->

This PR is about removing the DI for the consumer. The configuration should then be set when using the entry point `migrate`

## Pull-request quality

<!-- Please do not remove these, but leave them checked/unchecked as information for the reviewers -->
- [ ] The title adheres to [this guide](https://github.com/Mech0z/GitHubGuidelines)
- [ ] Tests are written and executed locally
- [ ] Subsystem tests have been tested (by manually deploying to `dev_002`)
