### PR TITLE
refac: Spark Sql Migrations - Move configuration (v2)

### DIFF
--- a/docs/migrations/README.md
+++ b/docs/migrations/README.md
@@ -36,8 +36,7 @@ spark_config = SparkSqlMigrationsConfiguration(
     catalog_name="spark_catalog",
 )
 
-create_and_configure_container(spark_config)
-migration_pipeline.migrate()
+migration_pipeline.migrate(spark_config)
 
 
 ```

--- a/docs/migrations/release-notes.md
+++ b/docs/migrations/release-notes.md
@@ -1,5 +1,13 @@
 # Spark SQL Migrations Release Notes
 
+## Version 3.1.0
+
+Following changes were made to simplify the package's usage and reduce the consumer's need to understand its
+implementation details
+
+- Removed the use of `create_and_configure_container` for the consumer.
+- The `migrate` function now takes `SparkSqlMigrationsConfigurations` as a parameter.
+
 ## Version 3.0.0
 
 Breaking changes

--- a/docs/migrations/release-notes.md
+++ b/docs/migrations/release-notes.md
@@ -1,6 +1,6 @@
 # Spark SQL Migrations Release Notes
 
-## Version 3.1.0
+## Version 5.0.0
 
 Following changes were made to simplify the package's usage and reduce the consumer's need to understand its
 implementation details

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "geh_common"
-version = "4.2.0"
+version = "5.0.0"
 description = "Functionality common to DataHub3 subsystems"
 readme = "README.md"
 

--- a/src/geh_common/migrations/__init__.py
+++ b/src/geh_common/migrations/__init__.py
@@ -1,11 +1,9 @@
 import geh_common.migrations.migration_pipeline as schema_migration_pipeline
-from geh_common.migrations.container import create_and_configure_container
 from geh_common.migrations.models.spark_sql_migrations_configuration import (
     SparkSqlMigrationsConfiguration,
 )
 
 __all__ = [
     "schema_migration_pipeline",
-    "create_and_configure_container",
     "SparkSqlMigrationsConfiguration",
 ]  # type: ignore

--- a/src/geh_common/migrations/migration_pipeline.py
+++ b/src/geh_common/migrations/migration_pipeline.py
@@ -1,8 +1,17 @@
 import geh_common.migrations.infrastructure.apply_migration_scripts as apply_migrations
 import geh_common.migrations.infrastructure.uncommitted_migration_scripts as uncommitted_migrations
+from src.geh_common.migrations import SparkSqlMigrationsConfiguration
+from geh_common.migrations.container import create_and_configure_container
 
+def migrate(configuration: SparkSqlMigrationsConfiguration) -> None:
+    _configure_spark_sql_migrations(configuration)
+    _migrate()
 
-def migrate() -> None:
+def _migrate() -> None:
     migrations: list[str] = uncommitted_migrations.get_uncommitted_migration_scripts()
     if len(migrations) > 0:
         (apply_migrations.apply_migration_scripts(migrations))
+
+def _configure_spark_sql_migrations(configuration: SparkSqlMigrationsConfiguration) -> None:
+    create_and_configure_container(configuration)
+    

--- a/src/geh_common/migrations/migration_pipeline.py
+++ b/src/geh_common/migrations/migration_pipeline.py
@@ -1,17 +1,19 @@
 import geh_common.migrations.infrastructure.apply_migration_scripts as apply_migrations
 import geh_common.migrations.infrastructure.uncommitted_migration_scripts as uncommitted_migrations
-from src.geh_common.migrations import SparkSqlMigrationsConfiguration
 from geh_common.migrations.container import create_and_configure_container
+from src.geh_common.migrations import SparkSqlMigrationsConfiguration
+
 
 def migrate(configuration: SparkSqlMigrationsConfiguration) -> None:
     _configure_spark_sql_migrations(configuration)
     _migrate()
+
 
 def _migrate() -> None:
     migrations: list[str] = uncommitted_migrations.get_uncommitted_migration_scripts()
     if len(migrations) > 0:
         (apply_migrations.apply_migration_scripts(migrations))
 
+
 def _configure_spark_sql_migrations(configuration: SparkSqlMigrationsConfiguration) -> None:
     create_and_configure_container(configuration)
-    

--- a/tests/migrations/unit/conftest.py
+++ b/tests/migrations/unit/conftest.py
@@ -11,11 +11,6 @@ import pytest
 from delta import configure_spark_with_delta_pip
 from pyspark.sql import SparkSession
 
-from geh_common.migrations.container import create_and_configure_container
-from tests.migrations.unit.builders.spark_sql_migrations_configuration_builder import (
-    build as build_configuration,
-)
-
 
 @pytest.fixture(scope="session")
 def spark() -> Generator[SparkSession, None, None]:

--- a/tests/migrations/unit/conftest.py
+++ b/tests/migrations/unit/conftest.py
@@ -17,14 +17,6 @@ from tests.migrations.unit.builders.spark_sql_migrations_configuration_builder i
 )
 
 
-def pytest_runtest_setup() -> None:
-    """
-    This function is called before each test function is executed.
-    """
-
-    create_and_configure_container(build_configuration())
-
-
 @pytest.fixture(scope="session")
 def spark() -> Generator[SparkSession, None, None]:
     warehouse_location = os.path.abspath("spark-warehouse")

--- a/tests/migrations/unit/infrastructure/test_uncommitted_migrations.py
+++ b/tests/migrations/unit/infrastructure/test_uncommitted_migrations.py
@@ -136,18 +136,21 @@ def test__get_uncommitted_migrations__when_one_migrations_needed__return_one() -
     migration1 = "migration1"
     migration2 = "migration2"
 
-    patch.object(
+    with patch.object(
         sut,
         sut.get_all_migration_scripts.__name__,
         return_value=[migration1, migration2],
-    )
-    patch.object(sut, sut._get_committed_migration_scripts.__name__, return_value=[migration1])
+    ) as mock_get_all_migration_scripts:
+        with patch.object(
+            sut, sut._get_committed_migration_scripts.__name__, return_value=[migration1]
+        ) as mock_get_committed_migration_scripts:
+            # Act
+            actual = sut.get_uncommitted_migration_scripts()
 
-    # Act
-    actual = sut.get_uncommitted_migration_scripts()
-
-    # Assert
-    assert len(actual) == 1
+            # Assert
+            assert len(actual) == 1
+            mock_get_all_migration_scripts.assert_called_once()
+            mock_get_committed_migration_scripts.assert_called_once()
 
 
 def test__get_uncommitted_migrations__when_multiple_migrations__return_in_correct_order() -> None:

--- a/tests/migrations/unit/test_schema_migration_pipeline.py
+++ b/tests/migrations/unit/test_schema_migration_pipeline.py
@@ -1,16 +1,17 @@
 from unittest.mock import patch
 
 import geh_common.migrations.migration_pipeline as sut
-
+import tests.migrations.unit.builders.spark_sql_migrations_configuration_builder as spark_sql_migrations_configuration_builder
 
 def test__migrate__when_no_uncommitted_migrations__should_not_call_apply_migrations() -> None:
     # Arrange
     with patch("geh_common.migrations.migration_pipeline.apply_migrations") as mocked_apply_migrations:
         with patch("geh_common.migrations.migration_pipeline.uncommitted_migrations") as mocked_uncommitted_migrations:
             mocked_uncommitted_migrations.get_uncommitted_migration_scripts.return_value = []
-
+            config = spark_sql_migrations_configuration_builder.build()
+            
             # Act
-            sut.migrate()
+            sut.migrate(config)
 
             # Assert
             mocked_apply_migrations.apply_migration_scripts.assert_not_called()
@@ -22,9 +23,10 @@ def test__migrate__when_uncommitted_migrations_not_zero__should_call_apply_migra
         with patch("geh_common.migrations.migration_pipeline.uncommitted_migrations") as mocked_uncommitted_migrations:
             mocked_uncommitted_migrations.get_uncommitted_migration_scripts.return_value = ["test_migration"]
             mocked_apply_migrations.apply_migration_scripts.side_effect = None
-
+            config = spark_sql_migrations_configuration_builder.build()
+            
             # Act
-            sut.migrate()
+            sut.migrate(config)
 
             # Assert
             mocked_apply_migrations.apply_migration_scripts.assert_called_once()

--- a/tests/migrations/unit/test_schema_migration_pipeline.py
+++ b/tests/migrations/unit/test_schema_migration_pipeline.py
@@ -3,13 +3,14 @@ from unittest.mock import patch
 import geh_common.migrations.migration_pipeline as sut
 import tests.migrations.unit.builders.spark_sql_migrations_configuration_builder as spark_sql_migrations_configuration_builder
 
+
 def test__migrate__when_no_uncommitted_migrations__should_not_call_apply_migrations() -> None:
     # Arrange
     with patch("geh_common.migrations.migration_pipeline.apply_migrations") as mocked_apply_migrations:
         with patch("geh_common.migrations.migration_pipeline.uncommitted_migrations") as mocked_uncommitted_migrations:
             mocked_uncommitted_migrations.get_uncommitted_migration_scripts.return_value = []
             config = spark_sql_migrations_configuration_builder.build()
-            
+
             # Act
             sut.migrate(config)
 
@@ -24,7 +25,7 @@ def test__migrate__when_uncommitted_migrations_not_zero__should_call_apply_migra
             mocked_uncommitted_migrations.get_uncommitted_migration_scripts.return_value = ["test_migration"]
             mocked_apply_migrations.apply_migration_scripts.side_effect = None
             config = spark_sql_migrations_configuration_builder.build()
-            
+
             # Act
             sut.migrate(config)
 

--- a/uv.lock
+++ b/uv.lock
@@ -409,7 +409,7 @@ wheels = [
 
 [[package]]
 name = "geh-common"
-version = "4.0.0"
+version = "4.2.0"
 source = { editable = "." }
 dependencies = [
     { name = "azure-core" },
@@ -436,7 +436,7 @@ requires-dist = [
     { name = "azure-core", specifier = ">=1.30.0,<2.0.0" },
     { name = "azure-identity", specifier = ">=1.16.1,<2.0.0" },
     { name = "azure-keyvault-secrets", specifier = ">=4.7.0,<5.0.0" },
-    { name = "azure-monitor-opentelemetry", specifier = ">=1.6.0,<2.0.0" },
+    { name = "azure-monitor-opentelemetry", specifier = ">=1.6.0,<1.6.5" },
     { name = "azure-monitor-query", specifier = ">=1.2.0,<2.0.0" },
     { name = "databricks-sdk", specifier = ">=0.42.0" },
     { name = "delta-spark", specifier = ">=3.1,<4.0" },


### PR DESCRIPTION
# Description

<!-- INSERT DESCRIPTION HERE -->
This PR is about removing the DI for the consumer. The configuration should then be set when using the entry point migrate

## References

<!-- ADD RELEVANT LINKS. FOR EXAMPLE A LINK TO THE ASSOCIATED STORY -->
