### PR TITLE
chore: limit dataframe materialization in assertions

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -16,7 +16,6 @@
     "github.copilot.editor.enableAutoCompletions": true,
     // Ruff Settings
     "ruff.lineLength": 120,
-    "ruff.lint.run": "onSave",
     "ruff.organizeImports": true,
     "[python]": {
         "editor.formatOnSave": true,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "geh_common"
-version = "5.2.1"
+version = "5.2.2"
 description = "Functionality common to DataHub3 subsystems"
 readme = "README.md"
 

--- a/uv.lock
+++ b/uv.lock
@@ -418,7 +418,7 @@ wheels = [
 
 [[package]]
 name = "geh-common"
-version = "5.2.0"
+version = "5.2.2"
 source = { editable = "." }
 dependencies = [
     { name = "azure-core" },
@@ -824,7 +824,7 @@ name = "portalocker"
 version = "2.10.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "pywin32", marker = "platform_system == 'Windows'" },
+    { name = "pywin32", marker = "sys_platform == 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/ed/d3/c6c64067759e87af98cc668c1cc75171347d0f1577fab7ca3749134e3cd4/portalocker-2.10.1.tar.gz", hash = "sha256:ef1bf844e878ab08aee7e40184156e1151f228f103aa5c6bd0724cc330960f8f", size = 40891 }
 wheels = [


### PR DESCRIPTION
# Description

Tried to limit the number of times that we materialize the dataframes in assertions to improve the overall performance. 

This has a huge potential payback as these functions are used in all python repos, and therefore a speed-up here will provide performance boosts in all packages. This is especially related to running `scenario_tests`

## Preliminary Results (Scenario Tests in Measurements)

### Before
<img width="663" alt="Screenshot 2025-02-24 at 16 58 56" src="https://github.com/user-attachments/assets/46ea5f77-3dcf-4b0e-8c02-31d8327d9ac0" />
<img width="670" alt="Screenshot 2025-02-25 at 15 03 32" src="https://github.com/user-attachments/assets/04dabcf8-af4f-4449-9872-ab53a66706de" />

### After
<img width="676" alt="Screenshot 2025-02-24 at 16 57 08" src="https://github.com/user-attachments/assets/4d582deb-f892-4b65-9578-39ef54b9e6b8" />
<img width="667" alt="Screenshot 2025-02-25 at 15 03 42" src="https://github.com/user-attachments/assets/922a428e-d6d5-4eb5-a833-5e2d49183c19" />

## References

<!-- ADD RELEVANT LINKS. FOR EXAMPLE A LINK TO THE ASSOCIATED STORY -->
