### PR TITLE
fix: Checkout CSV files with LF

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -20,6 +20,9 @@
 
 *.lss 	text
 
+# Force CSV files to use lf, which is required by the geh_common `read_csv()` function
+*.csv text eol=lf
+
 # Force bash scripts to always use lf line endings so that if a repo is accessed
 # in Unix via a file share from Windows, the scripts will work.
 *.in text eol=lf


### PR DESCRIPTION
# Description

<!-- INSERT DESCRIPTION HERE -->
The function `read_csv()` and [ADR-144](https://energinet.atlassian.net/wiki/spaces/D3/pages/1295483020/ADR+144+-+CSV+file+format+for+use+within+DataHub) requires CSV line endings to be LF. This PR ensures that the files are checked out this way so tests always works as expected (also on windows machines).

## References

<!-- ADD RELEVANT LINKS. FOR EXAMPLE A LINK TO THE ASSOCIATED STORY -->
