### PR TITLE
feat: Add GridAreaCodes type

### DIFF
--- a/source/geh_common/pyproject.toml
+++ b/source/geh_common/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "geh_common"
-version = "5.4.2"
+version = "5.4.3"
 description = "Functionality common to DataHub3 subsystems"
 readme = "README.md"
 

--- a/source/geh_common/release-notes.md
+++ b/source/geh_common/release-notes.md
@@ -1,5 +1,11 @@
 # GEH Common Release Notes
 
+## Version 5.4.3
+
+**Subpackage**: `geh_common.application`
+
+Added new GridAreaCodes type with a validator
+
 ## Version 5.4.2
 
 **Subpackage**: `geh_common.testing`

--- a/source/geh_common/src/geh_common/application/__init__.py
+++ b/source/geh_common/src/geh_common/application/__init__.py
@@ -1,3 +1,4 @@
 from geh_common.application import settings
+from geh_common.application.types.grid_area_codes import GridAreaCodes
 
-__all__ = ["settings"]
+__all__ = ["settings", "GridAreaCodes"]

--- a/source/geh_common/src/geh_common/application/types/grid_area_codes.py
+++ b/source/geh_common/src/geh_common/application/types/grid_area_codes.py
@@ -59,4 +59,14 @@ Validators:
 - BeforeValidator: Converts the input value to a list of grid area codes.
 - AfterValidator: Validates the list of grid area codes.
 - NoDecode: Prevents decoding of the input value.
+
+Example:
+```python
+class MySettings(BaseSettings):
+    grid_area_codes: GridAreaCodes
+
+args = MySettings(grid_area_codes="123,456,789")
+print(args.grid_area_codes)
+# Output: ['123', '456', '789']
+```
 """

--- a/source/geh_common/src/geh_common/application/types/grid_area_codes.py
+++ b/source/geh_common/src/geh_common/application/types/grid_area_codes.py
@@ -1,0 +1,61 @@
+import re
+from typing import Annotated, Any
+
+from pydantic import AfterValidator, BeforeValidator
+from pydantic_settings import NoDecode
+
+
+def _convert_grid_area_codes(value: Any) -> list[str] | None:
+    """Convert the input value to a list of grid area codes (strings).
+
+    Args:
+        value (Any): The input value to convert.
+
+    Returns:
+        Optional[List[str]]: A list of grid area codes or None if the input is empty.
+    """
+    if not value:
+        return None
+    if isinstance(value, list):
+        return [str(item) for item in value]
+    else:
+        return re.findall(r"\d+", value)
+
+
+def _validate_grid_area_codes(v: list[str] | None) -> list[str] | None:
+    """Validate the list of grid area codes.
+
+    Args:
+        v (Optional[List[str]]): The list of grid area codes to validate.
+
+    Returns:
+        Optional[List[str]]: The validated list of grid area codes.
+
+    Raises:
+        ValueError: If any grid area code is not a string of 3 digits.
+    """
+    if v is None:
+        return v
+    for code in v:
+        assert isinstance(code, str), f"Grid area codes must be strings, not {type(code)}"
+        if len(code) != 3 or not code.isdigit():
+            raise ValueError(
+                f"Unexpected grid area code: '{code}'. Grid area codes must consist of 3 digits (000-999)."
+            )
+    return v
+
+
+GridAreaCodes = Annotated[
+    list[str], BeforeValidator(_convert_grid_area_codes), AfterValidator(_validate_grid_area_codes), NoDecode
+]
+"""
+Annotated type for a list of grid area codes.
+
+This type ensures that the input is converted to a list of strings representing grid area codes,
+and that each code is validated to be a string of exactly 3 digits (000-999).
+
+Validators:
+- BeforeValidator: Converts the input value to a list of grid area codes.
+- AfterValidator: Validates the list of grid area codes.
+- NoDecode: Prevents decoding of the input value.
+"""

--- a/source/geh_common/src/geh_common/application/types/grid_area_codes.py
+++ b/source/geh_common/src/geh_common/application/types/grid_area_codes.py
@@ -37,7 +37,8 @@ def _validate_grid_area_codes(v: list[str] | None) -> list[str] | None:
     if v is None:
         return v
     for code in v:
-        assert isinstance(code, str), f"Grid area codes must be strings, not {type(code)}"
+        if not isinstance(code, str):
+            raise TypeError(f"Grid area codes must be strings, not {type(code)}")
         if len(code) != 3 or not code.isdigit():
             raise ValueError(
                 f"Unexpected grid area code: '{code}'. Grid area codes must consist of 3 digits (000-999)."
@@ -46,7 +47,7 @@ def _validate_grid_area_codes(v: list[str] | None) -> list[str] | None:
 
 
 GridAreaCodes = Annotated[
-    list[str], BeforeValidator(_convert_grid_area_codes), AfterValidator(_validate_grid_area_codes), NoDecode
+    list[str], BeforeValidator(_convert_grid_area_codes), AfterValidator(_validate_grid_area_codes), NoDecode()
 ]
 """
 Annotated type for a list of grid area codes.

--- a/source/geh_common/tests/application/types/test_grid_area_codes.py
+++ b/source/geh_common/tests/application/types/test_grid_area_codes.py
@@ -1,0 +1,103 @@
+from typing import Any
+
+import pytest
+from pydantic import BaseModel, ValidationError
+
+from geh_common.application import GridAreaCodes
+
+
+class TestModel(BaseModel):
+    grid_area_codes: GridAreaCodes
+
+
+def test__when_valid_grid_area_codes__returns_expected():
+    # Arrange
+    valid_codes = ["123", "456", "789"]
+
+    # Act
+    model = TestModel(grid_area_codes=valid_codes)
+
+    # Assert
+    assert model.grid_area_codes == valid_codes
+
+
+def test__when_valid_grid_area_codes_from_string__returns_list_of_grid_area_codes():
+    # Arrange
+    valid_codes_string = "123,456,789"
+    expected_codes = ["123", "456", "789"]
+
+    # Act
+    model = TestModel(grid_area_codes=valid_codes_string)
+
+    # Assert
+    assert model.grid_area_codes == expected_codes
+
+
+def test__when_empty_grid_area_codes__returns_empty_list():
+    # Arrange
+    empty_codes = []
+
+    # Act
+    model = TestModel(grid_area_codes=empty_codes)
+
+    # Assert
+    assert model.grid_area_codes == empty_codes
+
+
+def test__when_none_grid_area_codes__returns_none():
+    # Arrange
+    none_codes = None
+
+    # Act
+    model = TestModel(grid_area_codes=none_codes)
+
+    # Assert
+    assert model.grid_area_codes is None
+
+
+@pytest.mark.parametrize(
+    "invalid_code",
+    [
+        "12",  # not three characters
+        "4567",  # not three characters
+        "89a",  # not all digits
+    ],
+)
+def test__when_invalid_grid_area_codes__raises_exception(invalid_code: Any) -> None:
+    # Act & Assert
+    with pytest.raises(ValidationError) as exc_info:
+        TestModel(grid_area_codes=[invalid_code])
+
+    assert "Unexpected grid area code" in str(exc_info.value) or "Grid area codes must be strings" in str(
+        exc_info.value
+    )
+
+
+def test__when_list_of_valid_int__returns_list_of_strings():
+    # Arrange
+    valid_codes_string = [123, 456, 789]
+    expected_codes = ["123", "456", "789"]
+
+    # Act
+    model = TestModel(grid_area_codes=valid_codes_string)
+
+    # Assert
+    assert model.grid_area_codes == expected_codes
+
+
+@pytest.mark.parametrize(
+    "invalid_code",
+    [
+        1234,  # not three digits
+        1,  # not three digits
+        12,  # not three digits
+    ],
+)
+def test__when_invalid_int__raise_exception(invalid_code: Any) -> None:
+    # Act & Assert
+    with pytest.raises(ValidationError) as exc_info:
+        TestModel(grid_area_codes=[invalid_code])
+
+    assert "Unexpected grid area code" in str(exc_info.value) or "Grid area codes must be strings" in str(
+        exc_info.value
+    )

--- a/source/geh_common/tests/application/types/test_grid_area_codes.py
+++ b/source/geh_common/tests/application/types/test_grid_area_codes.py
@@ -14,6 +14,10 @@ class TestModelWithOptionalGridAreaCodes(BaseModel):
     grid_area_codes: GridAreaCodes | None = None
 
 
+class TestModelWithoutGridAreaCodes(BaseModel):
+    grid_area_codes: list[str] | None = None
+
+
 def test__when_valid_grid_area_codes__returns_expected() -> None:
     # Arrange
     valid_codes = ["123", "456", "789"]
@@ -118,3 +122,14 @@ def test__when_invalid_int__raise_exception(invalid_code: Any) -> None:
     assert "Unexpected grid area code" in str(exc_info.value) or "Grid area codes must be strings" in str(
         exc_info.value
     )
+
+
+def test__when_not_gridareacodes_type___returns_expected() -> None:
+    # Arrange
+    valid_codes = ["12", "whatever", "789"]
+
+    # Act
+    model = TestModelWithoutGridAreaCodes(grid_area_codes=valid_codes)
+
+    # Assert
+    assert model.grid_area_codes == valid_codes

--- a/source/geh_common/tests/application/types/test_grid_area_codes.py
+++ b/source/geh_common/tests/application/types/test_grid_area_codes.py
@@ -10,7 +10,11 @@ class TestModel(BaseModel):
     grid_area_codes: GridAreaCodes
 
 
-def test__when_valid_grid_area_codes__returns_expected():
+class TestModelWithOptionalGridAreaCodes(BaseModel):
+    grid_area_codes: GridAreaCodes | None = None
+
+
+def test__when_valid_grid_area_codes__returns_expected() -> None:
     # Arrange
     valid_codes = ["123", "456", "789"]
 
@@ -21,7 +25,7 @@ def test__when_valid_grid_area_codes__returns_expected():
     assert model.grid_area_codes == valid_codes
 
 
-def test__when_valid_grid_area_codes_from_string__returns_list_of_grid_area_codes():
+def test__when_valid_grid_area_codes_from_string__returns_list_of_grid_area_codes() -> None:
     # Arrange
     valid_codes_string = "123,456,789"
     expected_codes = ["123", "456", "789"]
@@ -33,26 +37,39 @@ def test__when_valid_grid_area_codes_from_string__returns_list_of_grid_area_code
     assert model.grid_area_codes == expected_codes
 
 
-def test__when_empty_grid_area_codes__returns_empty_list():
-    # Arrange
-    empty_codes = []
-
-    # Act
-    model = TestModel(grid_area_codes=empty_codes)
-
-    # Assert
-    assert model.grid_area_codes == empty_codes
-
-
-def test__when_none_grid_area_codes__returns_none():
+def test__when_none_grid_area_codes_and_optional__returns_none() -> None:
     # Arrange
     none_codes = None
 
     # Act
-    model = TestModel(grid_area_codes=none_codes)
+    model = TestModelWithOptionalGridAreaCodes(grid_area_codes=none_codes)
 
     # Assert
     assert model.grid_area_codes is None
+
+
+def test__when_empty_grid_area_codes__raises_exception() -> None:
+    # Arrange
+    empty_codes = []
+
+    # Act
+    with pytest.raises(ValidationError) as exc_info:
+        TestModel(grid_area_codes=empty_codes)
+
+    # Assert
+    assert "Input should be a valid list" in str(exc_info.value)
+
+
+def test__when_none_grid_area_codes_and_mandatory__raises_exception() -> None:
+    # Arrange
+    none_codes = None
+
+    # Act
+    with pytest.raises(ValidationError) as exc_info:
+        TestModel(grid_area_codes=none_codes)
+
+    # Assert
+    assert "Input should be a valid list" in str(exc_info.value)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
# Description

This new type can be used in connection with pydantic  BaseSettings. It will automatically validate the type and convert it to a list of strings


## References

<!-- ADD RELEVANT LINKS. FOR EXAMPLE A LINK TO THE ASSOCIATED STORY -->
