### PR TITLE
Update `@testing` decorator for DataFrameWrapper support and version bump to 5.4.5

### DIFF
--- a/source/geh_common/pyproject.toml
+++ b/source/geh_common/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "geh_common"
-version = "5.4.4"
+version = "5.4.5"
 description = "Functionality common to DataHub3 subsystems"
 readme = "README.md"
 

--- a/source/geh_common/release-notes.md
+++ b/source/geh_common/release-notes.md
@@ -4,7 +4,7 @@
 
 **Subpackage**: `geh_common.testing`
 
-Decorator `@testing` has been extended to support `DataFrameWrapper` and a selector function to 
+Decorator `@testing` has been extended to support `DataFrameWrapper` and a selector function to
 extract data frames from composite function results.
 
 ## Version 5.4.4

--- a/source/geh_common/release-notes.md
+++ b/source/geh_common/release-notes.md
@@ -1,5 +1,12 @@
 # GEH Common Release Notes
 
+## Version 5.4.5
+
+**Subpackage**: `geh_common.testing`
+
+Decorator `@testing` has been extended to support `DataFrameWrapper` and a selector function to 
+extract data frames from composite function results.
+
 ## Version 5.4.4
 
 **Subpackage**: `geh_common.databricks`

--- a/source/geh_common/tests/testing/unit/dataframes/test_logging.py
+++ b/source/geh_common/tests/testing/unit/dataframes/test_logging.py
@@ -1,8 +1,10 @@
 import inspect
+from typing import Tuple
 from unittest.mock import patch
 
 from pyspark.sql import DataFrame, SparkSession
 
+from geh_common.pyspark.data_frame_wrapper import DataFrameWrapper
 from geh_common.testing.dataframes.logging import (
     configure_testing,
     testing,
@@ -99,3 +101,48 @@ def test_log_dataframe(spark, capsys):
     assert "name" in captured.out
     assert "1" in captured.out
     assert "a" in captured.out
+
+
+##################################
+
+
+class MyDataFrameWrapper(DataFrameWrapper):
+    def __init__(self, df: DataFrame):
+        super().__init__(df=df, schema=df.schema)
+
+
+def test_decorator_when_function_return_dataframewrapper(spark: SparkSession) -> None:
+    # Arrange
+    configure_testing(True)
+    df = spark.createDataFrame([(1, "a"), (2, "b")], ["id", "name"])
+    wrapper = MyDataFrameWrapper(df)
+
+    @testing()
+    def dummy_function() -> DataFrameWrapper:
+        return wrapper
+
+    with patch("geh_common.testing.dataframes.logging._log_dataframe") as mock_log_dataframe:
+        # Act
+        dummy_function()
+
+        # Assert
+        mock_log_dataframe.assert_called_once()
+
+
+def test_decorator_when_used_multiple_times(spark: SparkSession) -> None:
+    # Arrange
+    configure_testing(True)
+    df = spark.createDataFrame([(1, "a"), (2, "b")], ["id", "name"])
+    wrapper = MyDataFrameWrapper(df)
+
+    @testing(selector=lambda result: result[0])
+    @testing(selector=lambda result: result[1])
+    def dummy_function() -> Tuple[DataFrame, DataFrameWrapper]:
+        return df, wrapper
+
+    with patch("geh_common.testing.dataframes.logging._log_dataframe") as mock_log_dataframe:
+        # Act
+        dummy_function()
+
+        # Assert
+        assert mock_log_dataframe.call_count == 2

--- a/source/geh_common/uv.lock
+++ b/source/geh_common/uv.lock
@@ -427,7 +427,7 @@ wheels = [
 
 [[package]]
 name = "geh-common"
-version = "5.4.2"
+version = "5.4.4"
 source = { editable = "." }
 dependencies = [
     { name = "azure-core" },


### PR DESCRIPTION
Enhance the `@testing` decorator to accommodate `DataFrameWrapper` and a selector function for improved data frame extraction. Update the version to 5.4.5 in the project configuration.