### PR TITLE
Extend orchestration types enum and update version

### DIFF
--- a/source/geh_common/pyproject.toml
+++ b/source/geh_common/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "geh_common"
-version = "5.4.5"
+version = "5.4.6"
 description = "Functionality common to DataHub3 subsystems"
 readme = "README.md"
 

--- a/source/geh_common/release-notes.md
+++ b/source/geh_common/release-notes.md
@@ -1,5 +1,11 @@
 # GEH Common Release Notes
 
+## Version 5.4.6
+
+**Subpackage**: `geh_common.domain.types`
+
+Extends enum `OrchestrationTypes` with more types and descriptions.
+
 ## Version 5.4.5
 
 **Subpackage**: `geh_common.testing`

--- a/source/geh_common/src/geh_common/domain/types/orchestration_type.py
+++ b/source/geh_common/src/geh_common/domain/types/orchestration_type.py
@@ -3,6 +3,17 @@ from enum import Enum
 
 class OrchestrationType(Enum):
     ELECTRICAL_HEATING = "electrical_heating"
+    """Process for calculation of electrical heating for households with electrical heating."""
     CAPACITY_SETTLEMENT = "capacity_settlement"
+    """Process for calculating the capacity settlement for the largest consumers on the grid."""
     SUBMITTED = "submitted"
+    """Process for submitting measurements from the process manager to measurements core."""
     MIGRATION = "migration"
+    """Process for transferring measurements from subsystem 'datamigrations' to measurements core.
+    The measurements from 'datamigrations' are migrated from DataHub 2."""
+    NET_CONSUMPTION = "net_consumption"
+    """Process that calculates the net consumption for net settlement group 6 households."""
+    MISSING_MEASUREMENTS_LOG = "missing_measurements_log"
+    """Process for calculating the missing metering points measurements in all grid areas."""
+    MISSING_MEASUREMENTS_LOG_ON_DEMAND = "missing_measurements_log_on_demand"
+    """Process for calculating the missing metering points measurements in selected grid areas."""

--- a/source/geh_common/uv.lock
+++ b/source/geh_common/uv.lock
@@ -427,7 +427,7 @@ wheels = [
 
 [[package]]
 name = "geh-common"
-version = "5.4.4"
+version = "5.4.5"
 source = { editable = "." }
 dependencies = [
     { name = "azure-core" },


### PR DESCRIPTION
Update the `OrchestrationType` enum to include additional types and descriptions, and increment the package version to 5.4.6.