### PR TITLE
refac: Updated databricks api client execute_statement method

### DIFF
--- a/source/geh_common/pyproject.toml
+++ b/source/geh_common/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "geh_common"
-version = "5.4.6"
+version = "5.4.7"
 description = "Functionality common to DataHub3 subsystems"
 readme = "README.md"
 

--- a/source/geh_common/release-notes.md
+++ b/source/geh_common/release-notes.md
@@ -1,5 +1,16 @@
 # GEH Common Release Notes
 
+## Version 5.4.7
+
+**Subpackage**: `geh_common.databricks`
+
+- Updated error message to include state. 
+
+- Increased the default timeout value. 
+
+- Now wait_for_response it set to true by default.
+
+
 ## Version 5.4.6
 
 **Subpackage**: `geh_common.domain.types`

--- a/source/geh_common/release-notes.md
+++ b/source/geh_common/release-notes.md
@@ -4,9 +4,9 @@
 
 **Subpackage**: `geh_common.databricks`
 
-- Updated error message to include state. 
+- Updated error message to include state.
 
-- Increased the default timeout value. 
+- Increased the default timeout value.
 
 - Now wait_for_response it set to true by default.
 

--- a/source/geh_common/release-notes.md
+++ b/source/geh_common/release-notes.md
@@ -10,7 +10,6 @@
 
 - Now wait_for_response it set to true by default.
 
-
 ## Version 5.4.6
 
 **Subpackage**: `geh_common.domain.types`

--- a/source/geh_common/src/geh_common/databricks/databricks_api_client.py
+++ b/source/geh_common/src/geh_common/databricks/databricks_api_client.py
@@ -132,8 +132,8 @@ class DatabricksApiClient:
             warehouse_id (str): The ID of the Databricks warehouse or cluster.
             statement (str): The SQL statement to execute.
             disposition (Disposition): Mode of result retrieval. Currently supports only Disposition.INLINE.
-            wait_for_response (bool, optional): Whether to wait for the execution result. Defaults to False.
-            timeout (int, optional): Maximum wait time in seconds when waiting for a response. Defaults to 360.
+            wait_for_response (bool, optional): Whether to wait for the execution result. Defaults to True.
+            timeout (int, optional): Maximum wait time in seconds when waiting for a response. Defaults to 600.
 
         Returns:
             StatementResponse: A StatementResponse object. It may optionally contain a `statement_id`, `status`,

--- a/source/geh_common/src/geh_common/databricks/databricks_api_client.py
+++ b/source/geh_common/src/geh_common/databricks/databricks_api_client.py
@@ -123,8 +123,8 @@ class DatabricksApiClient:
         warehouse_id: str,
         statement: str,
         disposition: Disposition = Disposition.INLINE,
-        wait_for_response: Optional[bool] = False,
-        timeout: Optional[int] = 360,
+        wait_for_response: Optional[bool] = True,
+        timeout: Optional[int] = 600,
     ) -> StatementResponse:
         """Execute a SQL statement. Only supports small result set (<= 25 MiB).
 
@@ -168,7 +168,9 @@ class DatabricksApiClient:
             if response.status.state == StatementState.SUCCEEDED:
                 return response
             else:
-                raise Exception(f"Statement execution failed: {response.status.error}")
+                raise Exception(
+                    f"Statement execution failed. Status: {response.status.state}. Error: {response.status.error}"
+                )
 
         except Exception as e:
             raise Exception(f"Failed to execute statement: {str(e)}")


### PR DESCRIPTION
# Description

- It now uses wait_for_repsonse by default default to prevent failures when the warehouse is not running. I [searching on github](https://github.com/search?q=org%3AEnerginet-DataHub%20execute_statement&type=code) to find all the places where the method is used, but it appears to only be in measurements where it will not break anything.


- Increase the timeout value to 10 minutes.
- Updated the error message to include the state for easier debugging.

## References

<!-- ADD RELEVANT LINKS. FOR EXAMPLE A LINK TO THE ASSOCIATED STORY -->
