### PR TITLE
fix: Added missing Metering Point Type

### DIFF
--- a/source/geh_common/pyproject.toml
+++ b/source/geh_common/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "geh_common"
-version = "5.4.8"
+version = "5.4.9"
 description = "Functionality common to DataHub3 subsystems"
 readme = "README.md"
 

--- a/source/geh_common/release-notes.md
+++ b/source/geh_common/release-notes.md
@@ -1,6 +1,6 @@
 # GEH Common Release Notes
 
-## Version 5.4.6
+## Version 5.4.9
 
 **Subpackage**: `geh_common.domain.types`
 

--- a/source/geh_common/release-notes.md
+++ b/source/geh_common/release-notes.md
@@ -4,7 +4,7 @@
 
 **Subpackage**: `geh_common.domain.types`
 
-Extends enum `MeteringPointTypes` with one more type and description.
+Extends enum `MeteringPointTypes` with one more type used in DH2.
 
 ## Version 5.4.8
 

--- a/source/geh_common/release-notes.md
+++ b/source/geh_common/release-notes.md
@@ -1,5 +1,11 @@
 # GEH Common Release Notes
 
+## Version 5.4.6
+
+**Subpackage**: `geh_common.domain.types`
+
+Extends enum `MeteringPointTypes` with one more type and description.
+
 ## Version 5.4.8
 
 **Subpackage**: `geh_common.testing`

--- a/source/geh_common/src/geh_common/domain/types/metering_point_type.py
+++ b/source/geh_common/src/geh_common/domain/types/metering_point_type.py
@@ -12,6 +12,7 @@ class MeteringPointType(Enum):
     ELECTRICAL_HEATING = "electrical_heating"
     EXCHANGE = "exchange"  # Parent
     EXCHANGE_REACTIVE_ENERGY = "exchange_reactive_energy"
+    INTERNAL_USE = "internal_use"
     NET_CONSUMPTION = "net_consumption"
     NET_FROM_GRID = "net_from_grid"
     NET_LOSS_CORRECTION = "net_loss_correction"


### PR DESCRIPTION
# Description
When mapping DH2 types to DH3 types we realised that we are missing the extremely rare "internal_use" type D99.
This PR simply adds it here, so it can be used in measurements. 
