### PR TITLE
Feat: Adjust the unit value to be mapped to correct abbreviations.

### DIFF
--- a/source/geh_common/pyproject.toml
+++ b/source/geh_common/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "geh_common"
-version = "5.4.9"
+version = "5.5.0"
 description = "Functionality common to DataHub3 subsystems"
 readme = "README.md"
 

--- a/source/geh_common/release-notes.md
+++ b/source/geh_common/release-notes.md
@@ -1,5 +1,11 @@
 # GEH Common Release Notes
 
+## Version 5.5.0
+
+**Subpackage**: `geh_common.domain.types`
+
+Modifies enum `QuantityUnit` to map to the correct abbreviation values.
+
 ## Version 5.4.9
 
 **Subpackage**: `geh_common.domain.types`

--- a/source/geh_common/src/geh_common/domain/types/quantity_unit.py
+++ b/source/geh_common/src/geh_common/domain/types/quantity_unit.py
@@ -2,8 +2,8 @@ from enum import Enum
 
 
 class QuantityUnit(Enum):
-    KWH = "KWH"
-    KW = "KW"
-    KVARH = "KVARH"
-    MWH = "MWH"
-    TONNE = "TONNE"
+    KWH = "kWh"
+    KW = "kW"
+    KVARH = "kVArh"
+    MWH = "MWh"
+    TONNE = "Tonne"


### PR DESCRIPTION
This pull request includes changes to update the version of the `geh_common` package and modify the `QuantityUnit` enum to map to the correct abbreviation values. The most important changes are as follows:

Version update:

* [`source/geh_common/pyproject.toml`](diffhunk://#diff-11237ce113b7204cb372fdfeb1722d9fbca234846635f7e180822d8f8a91e621L3-R3): Updated the version from `5.4.9` to `5.5.0`.

Release notes:

* [`source/geh_common/release-notes.md`](diffhunk://#diff-7025a0f8f1cd26baaf8327eb546e1f73a7bc448359ebb17f9e03d3ac36058db6R3-R8): Added release notes for version `5.5.0` detailing the changes made to the `QuantityUnit` enum.

Enum modification:

* [`source/geh_common/src/geh_common/domain/types/quantity_unit.py`](diffhunk://#diff-201446f6cfe95790ec1b816af9fbd9cdc83ba91d67b81da86ad3413f707f4692L5-R9): Modified the `QuantityUnit` enum to map to the correct abbreviation values (e.g., `KWH` to `kWh`, `KW` to `kW`).