### PR TITLE
Bump delta-spark dependency for liquid clustering support

### DIFF
--- a/source/geh_common/pyproject.toml
+++ b/source/geh_common/pyproject.toml
@@ -7,7 +7,7 @@ readme = "README.md"
 requires-python = ">=3.11"
 dependencies = [
     "pyspark>=3.5.0",
-    "delta-spark>=3.1,<4.0",
+    "delta-spark>=3.3,<4.0",
     "dependency_injector>=4.43.0,<5.0",
     "azure-monitor-opentelemetry>=1.6.0",
     "azure-core>=1.30.0,<2.0.0",

--- a/source/geh_common/release-notes.md
+++ b/source/geh_common/release-notes.md
@@ -1,5 +1,16 @@
 # GEH Common Release Notes
 
+## Version 5.6.4
+
+Bump to delta-spark>=3.3.0 dependency to ensure support for adding liquid clustering to
+existing tables without clustering enabled.
+
+With 3.3.0 clustering can be added like:
+
+```sql
+ALTER TABLE your_table_name CLUSTER BY column_name
+```
+
 ## Version 5.6.3
 
 - changed contract in measurements_core to be not nullable

--- a/source/geh_common/uv.lock
+++ b/source/geh_common/uv.lock
@@ -436,7 +436,7 @@ wheels = [
 
 [[package]]
 name = "geh-common"
-version = "5.6.2"
+version = "5.6.3"
 source = { editable = "." }
 dependencies = [
     { name = "azure-core" },
@@ -470,7 +470,7 @@ requires-dist = [
     { name = "azure-monitor-opentelemetry", specifier = ">=1.6.0" },
     { name = "azure-monitor-query", specifier = ">=1.2.0,<2.0.0" },
     { name = "databricks-sdk", specifier = ">=0.42.0" },
-    { name = "delta-spark", specifier = ">=3.1,<4.0" },
+    { name = "delta-spark", specifier = ">=3.3,<4.0" },
     { name = "dependency-injector", specifier = ">=4.43.0,<5.0" },
     { name = "pydantic", specifier = ">=2.10.6" },
     { name = "pydantic-settings", specifier = ">=2.7.1" },


### PR DESCRIPTION
Update the delta-spark dependency to version 3.3.0 or higher to enable liquid clustering functionality in existing tables.