### PR TITLE
fix: cannot import name 'get_dist_dependency_conflicts' from 'opentelemetry.instrumentation.dependencies'

### DIFF
--- a/source/geh_common/pyproject.toml
+++ b/source/geh_common/pyproject.toml
@@ -7,7 +7,7 @@ readme = "README.md"
 requires-python = ">=3.11"
 dependencies = [
     "pyspark>=3.5.0",
-    "delta-spark>=3.1,<4.0",
+    "delta-spark>=3.3,<4.0",
     "dependency_injector>=4.43.0,<5.0",
     "azure-monitor-opentelemetry>=1.6.7",
     "azure-core>=1.30.0,<2.0.0",

--- a/source/geh_common/pyproject.toml
+++ b/source/geh_common/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "geh_common"
-version = "5.5.0"
+version = "5.7.0"
 description = "Functionality common to DataHub3 subsystems"
 readme = "README.md"
 

--- a/source/geh_common/pyproject.toml
+++ b/source/geh_common/pyproject.toml
@@ -1,15 +1,15 @@
 [project]
 name = "geh_common"
-version = "5.6.6"
+version = "5.5.0"
 description = "Functionality common to DataHub3 subsystems"
 readme = "README.md"
 
 requires-python = ">=3.11"
 dependencies = [
     "pyspark>=3.5.0",
-    "delta-spark>=3.3,<4.0",
+    "delta-spark>=3.1,<4.0",
     "dependency_injector>=4.43.0,<5.0",
-    "azure-monitor-opentelemetry>=1.6.0",
+    "azure-monitor-opentelemetry>=1.6.7",
     "azure-core>=1.30.0,<2.0.0",
     "azure-identity>=1.16.1,<2.0.0",
     "azure-keyvault-secrets>=4.7.0,<5.0.0",

--- a/source/geh_common/release-notes.md
+++ b/source/geh_common/release-notes.md
@@ -1,5 +1,13 @@
 # GEH Common Release Notes
 
+## Version 5.7.0
+
+Workflows started to get the error:
+
+- ImportError: cannot import name 'get_dist_dependency_conflicts' from 'opentelemetry.instrumentation.dependencies'
+
+According to <https://github.com/Azure/azure-sdk-for-python/issues/40465> this was a breaking change introduced, but should be fixed in 1.6.7
+
 ## Version 5.6.6
 
 **Subpackage**: `testing.delta_lake`


### PR DESCRIPTION
# Description

Streams started to die due to the error:
`cannot import name 'get_dist_dependency_conflicts' from 'opentelemetry.instrumentation.dependencies'`

This was a breaking change introduced within the package, and was fixed in 1.6.7 according to the following issue:
https://github.com/Azure/azure-sdk-for-python/issues/40465

## References

<!-- ADD RELEVANT LINKS. FOR EXAMPLE A LINK TO THE ASSOCIATED STORY -->
