### PR TITLE
Add clamp functions for period start and end, update version to 5.8.8

### DIFF
--- a/source/geh_common/pyproject.toml
+++ b/source/geh_common/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "geh_common"
-version = "5.8.7"
+version = "5.8.8"
 description = "Functionality common to DataHub3 subsystems"
 readme = "README.md"
 

--- a/source/geh_common/release-notes.md
+++ b/source/geh_common/release-notes.md
@@ -1,5 +1,9 @@
 # GEH Common Release Notes
 
+## Version 5.8.8
+
+Add `geh_common.pyspark.clamp` functions to clamp periods.
+
 ## Version 5.8.7
 
 - Improves docstring for `get_spark_test_session` function in `geh_common.testing` subpackage. Now the origin of the configurations used should be apparent.

--- a/source/geh_common/src/geh_common/pyspark/clamp.py
+++ b/source/geh_common/src/geh_common/pyspark/clamp.py
@@ -1,0 +1,18 @@
+from datetime import datetime
+
+import pyspark.sql.functions as F
+from pyspark.sql import Column
+
+
+def clamp_period_start(col: str | Column, clamp_start_datetime: datetime) -> Column:
+    """Clamp the start of a period to a given datetime."""
+    if isinstance(col, str):
+        col = F.col(col)
+    return F.when(col.isNull() | (col < clamp_start_datetime), clamp_start_datetime).otherwise(col)
+
+
+def clamp_period_end(col: str | Column, clamp_end_datetime: datetime) -> Column:
+    """Clamp the end of a period to a given datetime."""
+    if isinstance(col, str):
+        col = F.col(col)
+    return F.when(col.isNull() | (col > clamp_end_datetime), clamp_end_datetime).otherwise(col)

--- a/source/geh_common/src/geh_common/testing/dataframes/assert_dataframes.py
+++ b/source/geh_common/src/geh_common/testing/dataframes/assert_dataframes.py
@@ -97,7 +97,7 @@ def assert_dataframes_and_schemas(
         raise
 
     try:
-        _assert_dataframes(actual, expected)
+        assert_dataframes_equal(actual, expected)
     except AssertionError:
         if not configuration.show_columns_when_actual_and_expected_are_equal:
             actual, expected = _drop_columns_if_the_same(actual, expected)
@@ -121,7 +121,7 @@ def assert_dataframes_and_schemas(
         raise
 
 
-def _assert_dataframes(actual: DataFrame, expected: DataFrame) -> None:
+def assert_dataframes_equal(actual: DataFrame, expected: DataFrame) -> None:
     actual_excess = actual.subtract(expected)
     expected_excess = expected.subtract(actual)
 
@@ -136,7 +136,9 @@ def _assert_dataframes(actual: DataFrame, expected: DataFrame) -> None:
         print("Expected excess:")  # noqa
         expected_excess.show(3000, False)
 
-    assert actual_excess_count == 0 and expected_excess_count == 0, "Dataframes data are not equal"
+    assert actual.count() == expected.count() and actual_excess_count == 0 and expected_excess_count == 0, (
+        "Dataframes data are not equal"
+    )
 
 
 def _assert_no_duplicates(df: DataFrame, original_count: int) -> None:

--- a/source/geh_common/tests/pyspark/unit/test_clamp.py
+++ b/source/geh_common/tests/pyspark/unit/test_clamp.py
@@ -1,0 +1,62 @@
+from datetime import UTC, datetime
+
+from pyspark.sql import SparkSession
+from pyspark.sql.functions import col
+from pyspark.sql.types import StructField, StructType, TimestampType
+
+from geh_common.pyspark.clamp import clamp_period_end, clamp_period_start
+from geh_common.testing.dataframes.assert_dataframes import assert_dataframes_equal
+
+
+def test_clamp_period_start(spark: SparkSession):
+    # Arrange
+    data = [
+        (None,),
+        (datetime(2024, 1, 5, tzinfo=UTC),),
+        (datetime(2025, 1, 1, tzinfo=UTC),),
+        (datetime(2025, 5, 1, tzinfo=UTC),),
+    ]
+    schema = StructType([StructField("period_start", TimestampType(), True)])
+    df = spark.createDataFrame(data, schema)
+    clamp_start_datetime = datetime(2025, 1, 1)
+
+    expected_data = [
+        (clamp_start_datetime,),
+        (clamp_start_datetime,),
+        (clamp_start_datetime,),
+        (datetime(2025, 5, 1, tzinfo=UTC),),
+    ]
+    expected = spark.createDataFrame(expected_data, schema)
+
+    # Act
+    actual = df.withColumn("period_start", clamp_period_start(col("period_start"), clamp_start_datetime))
+
+    # Assert
+    assert_dataframes_equal(actual, expected)
+
+
+def test_clamp_period_end(spark):
+    # Arrange
+    data = [
+        (None,),
+        (datetime(2024, 1, 5, tzinfo=UTC),),
+        (datetime(2025, 1, 1, tzinfo=UTC),),
+        (datetime(2025, 5, 1, tzinfo=UTC),),
+    ]
+    schema = StructType([StructField("period_end", TimestampType(), True)])
+    df = spark.createDataFrame(data, schema)
+    clamp_end_datetime = datetime(2025, 1, 1)
+
+    expected_data = [
+        (clamp_end_datetime,),
+        (datetime(2024, 1, 5, tzinfo=UTC),),
+        (clamp_end_datetime,),
+        (clamp_end_datetime,),
+    ]
+    expected = spark.createDataFrame(expected_data, schema)
+
+    # Act
+    actual = df.withColumn("period_end", clamp_period_end(col("period_end"), clamp_end_datetime))
+
+    # Assert
+    assert_dataframes_equal(actual, expected)

--- a/source/geh_common/uv.lock
+++ b/source/geh_common/uv.lock
@@ -488,7 +488,7 @@ wheels = [
 
 [[package]]
 name = "geh-common"
-version = "5.8.5"
+version = "5.8.6"
 source = { editable = "." }
 dependencies = [
     { name = "azure-core" },


### PR DESCRIPTION
Introduce `clamp_period_start` and `clamp_period_end` functions to manage period boundaries. Update the project version to 5.8.8 and document the changes in the release notes.