### PR TITLE
contracts: energy supplier must be present when exposing parent mp periods for electrical heating and net consumption calculations

### DIFF
--- a/source/geh_common/pyproject.toml
+++ b/source/geh_common/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "geh_common"
-version = "6.1.3"
+version = "6.1.4"
 description = "Functionality common to DataHub3 subsystems"
 readme = "README.md"
 

--- a/source/geh_common/release-notes.md
+++ b/source/geh_common/release-notes.md
@@ -1,5 +1,9 @@
 # GEH Common Release Notes
 
+## Version 6.1.4
+
+- Update contracts for electrical heating and net consumption periodisations
+
 ## Version 6.1.3
 
 - Update measurements_current_v1 schema

--- a/source/geh_common/src/geh_common/data_products/electricity_market_measurements_input/electrical_heating_consumption_metering_point_periods_v1.py
+++ b/source/geh_common/src/geh_common/data_products/electricity_market_measurements_input/electrical_heating_consumption_metering_point_periods_v1.py
@@ -56,6 +56,7 @@ The data is periodized; the following transaction types are relevant for determi
 - MANCOR (HTX): Manuelt korrigering
 Periods are  included when
 - the metering point physical status is connected or disconnected
+- an energy supplier is registered
 - the period does not end before 2021-01-01
 - electrical heating is registered for the period
 """

--- a/source/geh_common/src/geh_common/data_products/electricity_market_measurements_input/net_consumption_group_6_consumption_metering_point_periods_v1.py
+++ b/source/geh_common/src/geh_common/data_products/electricity_market_measurements_input/net_consumption_group_6_consumption_metering_point_periods_v1.py
@@ -54,6 +54,7 @@ The data is periodized; the following transaction types are relevant for determi
 Periods are included when:
 - the parent metering point is in netsettlement group 6
 - the metering point physical status is connected or disconnected
+- an energy supplier is registered
 - the period does not end before 2021-01-01
 
 Formatting is according to ADR-144 with the following constraints:


### PR DESCRIPTION
# Description
Energy supplier must be present when exposing parent mp periods for electrical heating and net consumption calculations.
Discussed with Khatozen, Claus and Jesper before adding this PR.

Based on this doc:
<img width="1534" height="361" alt="image" src="https://github.com/user-attachments/assets/0f653f06-a765-469e-b3bb-2cb16e3d8166" />




## References

<!-- ADD RELEVANT LINKS. FOR EXAMPLE A LINK TO THE ASSOCIATED STORY -->
