### PR TITLE
fix: Extend analyze_table to do DELTA statistics.

### DIFF
--- a/source/geh_common/src/geh_common/databricks/optimizations/analyze.py
+++ b/source/geh_common/src/geh_common/databricks/optimizations/analyze.py
@@ -1,7 +1,7 @@
 from pyspark.sql.session import SparkSession
 
 
-def analyze_table(spark: SparkSession, database: str, table: str, analyze_columns: str | None = None) -> None:
+def analyze_table(spark: SparkSession, database: str, table: str, analyze_columns: str | None = None, analyze_delta: bool = False) -> None:
     """Analyze the specified table in the given database.
 
     Analyze helps query performance by collecting statistics on the table.
@@ -12,7 +12,10 @@ def analyze_table(spark: SparkSession, database: str, table: str, analyze_column
       table: The name of the table to analyze.
       analyze_columns (optional): The columns to analyze (preferably cluster keys).
     """
-    if analyze_columns:
+    if analyze_delta:
+        print(f"Analyzing delta statistics")  # noqa: T201
+        sql = f"ANALYZE TABLE {database}.{table} COMPUTE DELTA STATISTICS" 
+    elif analyze_columns:
         print(f"Analyzing columns: {analyze_columns}")  # noqa: T201
         sql = f"ANALYZE TABLE {database}.{table} COMPUTE STATISTICS FOR COLUMNS {analyze_columns}"
     else:

--- a/source/geh_common/tests/databricks/unit/optimizations/test_analyze.py
+++ b/source/geh_common/tests/databricks/unit/optimizations/test_analyze.py
@@ -30,3 +30,17 @@ def test__analyze_table__when_analyze_columns_parsed__executes_expected_sql() ->
     # Assert
     expected_sql = f"ANALYZE TABLE {database}.{table} COMPUTE STATISTICS FOR COLUMNS {analyze_columns}"
     mocked_spark.sql.assert_called_once_with(expected_sql)
+
+
+def test__analyze_table__when_analyze_delta_is_true__executes_expected_sql() -> None:
+    # Arrange
+    mocked_spark = mock.Mock()
+    database = "test_database"
+    table = "test_table"
+
+    # Act
+    sut.analyze_table(mocked_spark, database, table, analyze_delta=True)
+
+    # Assert
+    expected_sql = f"ANALYZE TABLE {database}.{table} COMPUTE DELTA STATISTICS"
+    mocked_spark.sql.assert_called_once_with(expected_sql)


### PR DESCRIPTION
# Description

Changes the analyze_table command to also be able to do "ANALYZE TABLE ... COMPUTE DELTA STATISTICS" which is a separate kind of command from "COMPUTE STATISTICS FOR ALL COLUMNS". 

The key difference is that the result of the new one is used for File Skipping within Delta, which can improve Liquid Clustering performance (in theory...)

## References

Going to be used in a benchmarking experiment on Measurements for ADR149 / ADR153.
