### PR TITLE
chore: Bump versions

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -27,7 +27,7 @@ permissions:
 jobs:
   cd_reusable:
     name: Continuous Deployment
-    uses: Energinet-DataHub/.github/.github/workflows/python-uv-cd.yml@workflows/v2
+    uses: Energinet-DataHub/.github/.github/workflows/python-uv-cd.yml@workflows/v3
     with:
       packages_directory: source
       subsystem_name: common

--- a/.github/workflows/ci-orchestrator.yml
+++ b/.github/workflows/ci-orchestrator.yml
@@ -20,7 +20,7 @@ jobs:
   # License and Markdown Check
   #
   ci_base:
-    uses: Energinet-DataHub/.github/.github/workflows/ci-base.yml@workflows/v1
+    uses: Energinet-DataHub/.github/.github/workflows/ci-base.yml@workflows/v3
     with:
       skip_license_check: true
     secrets:
@@ -41,7 +41,7 @@ jobs:
   #
   ci_unit:
     name: Unit tests
-    uses: Energinet-DataHub/.github/.github/workflows/python-uv-ci.yml@workflows/v2
+    uses: Energinet-DataHub/.github/.github/workflows/python-uv-ci.yml@workflows/v3
     with:
       packages_directory: source
       create_versioned_release: true
@@ -52,7 +52,7 @@ jobs:
   #
   ci_integration:
     name: Integration tests
-    uses: Energinet-DataHub/.github/.github/workflows/python-uv-ci.yml@workflows/v2
+    uses: Energinet-DataHub/.github/.github/workflows/python-uv-ci.yml@workflows/v3
     with:
       packages_directory: source
       environment: AzureAuth

--- a/.github/workflows/docker-build-push.yml
+++ b/.github/workflows/docker-build-push.yml
@@ -70,10 +70,10 @@ jobs:
           fi
 
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Check if ${{ inputs.image_name }} has changed
-        uses: dorny/paths-filter@v3
+        uses: dorny/paths-filter@v4
         id: changes
         with:
           filters: |
@@ -95,11 +95,11 @@ jobs:
         if: ${{ steps.changes.outputs.is_changed == 'true' }}
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
         if: ${{ steps.changes.outputs.is_changed == 'true' }}
 
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         if: ${{ steps.changes.outputs.is_changed == 'true' }}
         with:
           registry: ${{ inputs.registry }}
@@ -119,7 +119,7 @@ jobs:
           echo "IMAGE_FQN=${IMAGE_FQN}" >> $GITHUB_OUTPUT
 
       - name: Build and Push ${{ inputs.image_name }}:${{ inputs.image_tag }}
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v7
         if: ${{ steps.changes.outputs.is_changed == 'true' }}
         with:
           build-args: ${{ inputs.build-args }}


### PR DESCRIPTION
This pull request updates several GitHub Actions workflow files to use newer versions of reusable workflows and third-party actions. The main goal is to keep the CI/CD pipelines up-to-date with the latest features, improvements, and security patches from upstream dependencies.

**Workflow version upgrades:**

* Upgraded reusable workflow references in `.github/workflows/ci-orchestrator.yml` to use `workflows/v3` for both `ci-base.yml` and `python-uv-ci.yml`, affecting the `ci_base`, `ci_unit`, and `ci_integration` jobs. [[1]](diffhunk://#diff-c2a8e2dd83b46864483c9706f8e843ef2eef7e0a17b4ae45194a5a671e3c8739L23-R23) [[2]](diffhunk://#diff-c2a8e2dd83b46864483c9706f8e843ef2eef7e0a17b4ae45194a5a671e3c8739L44-R44) [[3]](diffhunk://#diff-c2a8e2dd83b46864483c9706f8e843ef2eef7e0a17b4ae45194a5a671e3c8739L55-R55)
* Updated the reusable workflow reference in `.github/workflows/cd.yml` to use `workflows/v3` for `python-uv-cd.yml` in the `cd_reusable` job.

**Third-party GitHub Action upgrades:**

* Updated action versions in `.github/workflows/docker-build-push.yml`:
  - `actions/checkout` from `v4` to `v6`
  - `dorny/paths-filter` from `v3` to `v4`
  - `docker/setup-buildx-action` from `v3` to `v4`
  - `docker/login-action` from `v3` to `v4`
  - `docker/build-push-action` from `v5` to `v7`