### PR TITLE
removed electrical_heating_active from commercial_relations_v1

### DIFF
--- a/source/geh_common/pyproject.toml
+++ b/source/geh_common/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "geh_common"
-version = "8.0.0"
+version = "8.0.1"
 description = "Functionality common to DataHub3 subsystems"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/source/geh_common/release-notes.md
+++ b/source/geh_common/release-notes.md
@@ -1,6 +1,6 @@
 # GEH Common Release Notes
 
-## Version 8.0.0
+## Version 8.0.1
 
 - Removed ´ElectricalHeatingActive`from commercial_relations_v1 data product.
 

--- a/source/geh_common/release-notes.md
+++ b/source/geh_common/release-notes.md
@@ -2,7 +2,7 @@
 
 ## Version 8.0.1
 
-- Removed ´ElectricalHeatingActive`from commercial_relations_v1 data product.
+- Removed `electrical_heating_active` from `commercial_relations_v1` data product.
 
 ## Version 8.0.0
 

--- a/source/geh_common/release-notes.md
+++ b/source/geh_common/release-notes.md
@@ -2,6 +2,10 @@
 
 ## Version 8.0.0
 
+- Removed ´ElectricalHeatingActive`from commercial_relations_v1 data product.
+
+## Version 8.0.0
+
 - Rename type `GridAreaCodes` to `GridAreaIds`.
 - Added type `ConnectionStates`.
 

--- a/source/geh_common/src/geh_common/data_products/electricity_market_gold/commercial_relations_v1.py
+++ b/source/geh_common/src/geh_common/data_products/electricity_market_gold/commercial_relations_v1.py
@@ -25,7 +25,6 @@ schema = T.StructType(
             ),
             not nullable,
         ),
-        T.StructField("electrical_heating_active", T.BooleanType(), not nullable),
         T.StructField("is_current", T.BooleanType(), not nullable),
         T.StructField(
             "energy_supplier_periods",


### PR DESCRIPTION
# Description
electrical_heating_active has been removed from the view (and table)
## References

<!-- ADD RELEVANT LINKS. FOR EXAMPLE A LINK TO THE ASSOCIATED STORY -->
